### PR TITLE
Update views on rotation

### DIFF
--- a/NutriScoreLogo/NutriScoreView.swift
+++ b/NutriScoreLogo/NutriScoreView.swift
@@ -186,9 +186,9 @@ class NutriScoreView: UIView {
             return nil
         }
     }
-
-    override func draw(_ rect: CGRect) {
+    
+    override func layoutSubviews() {
+        super.layoutSubviews()
         setupViews()
     }
-    
 }


### PR DESCRIPTION
Instead of calling `setupViews` on `draw:rect`, calling it in `layoutSubviews:` where the new frame is already set, so `scale` can be recalculated with the new width. 

The only problem I see (specially when enabling Slow animations on the simulator) is that `setupViews` ends before the rotation animation starts, so you can see the labels with the new sizes before the views rotate. I tried wrapping `setupViews` inside an animation block without effect.

`draw:rect` will be called by UIKit on rotation when setting `view.contentMode = UIViewContentModeRedraw` (default value is `scaleToFill`), but I've [read](https://stackoverflow.com/a/3792022/1283228) that implementing `draw:rect` reduces performance because a graphic context is created to be used in the method.